### PR TITLE
Add Referrer Policy headers

### DIFF
--- a/nginx-partials/security.conf
+++ b/nginx-partials/security.conf
@@ -9,3 +9,9 @@ add_header X-Content-Type-Options "nosniff";
 # HTTP Header.  See https://content-security-policy.com/
 # Uncomment this only if you know what you're doing; it will need tweaking
 #add_header Content-Security-Policy "default-src https: data: 'unsafe-inline' 'unsafe-eval'" always;
+
+# Add Referrer Policy HTTP response header. The Referrer-Policy HTTP header
+# governs which referrer information should be included with requests made.
+# Prevents referrer data from leaking on insecure connections.
+# See https://scotthelme.co.uk/a-new-security-header-referrer-policy/
+add_header Referrer-Policy "no-referrer-when-downgrade";


### PR DESCRIPTION
Add Referrer Policy HTTP response header. The Referrer-Policy HTTP header governs which referrer information should be included with requests made. Prevents referrer data from leaking on insecure connections. [Read more](https://scotthelme.co.uk/a-new-security-header-referrer-policy/)