### PR TITLE
Add SVG to cache-busted extensions

### DIFF
--- a/nginx-partials/cache-busting.conf
+++ b/nginx-partials/cache-busting.conf
@@ -6,8 +6,8 @@
 # Read also this: github.com/h5bp/html5-boilerplate/wiki/cachebusting
 # This is not included by default, because it'd be better if you use the build
 # script to manage the file names.
-location ~* (.+)\.(?:\d+)\.(js|css|png|jpg|jpeg|gif|webp)$ {
-	etag off;
+location ~* (.+)\.(?:\d+)\.(js|css|png|jpg|svg|jpeg|gif|webp)$ {
+    etag off;
     expires 1M;
     access_log off;
     add_header Cache-Control "public";


### PR DESCRIPTION
While SVGs are usually part of some other build script, it would seem sensible to include .svg as an extension that should have cache busting logic included along with other image formats.

Also fixed a whitespace issue.