### PR TITLE
Fix multi-site requests missing query params

### DIFF
--- a/forge-example/NginxConfiguration.conf
+++ b/forge-example/NginxConfiguration.conf
@@ -98,7 +98,7 @@ server {
     # you need to support
 
     #location @enrewrites {
-    #    rewrite ^/en/(.*)$ /en/index.php?p=$1? last;
+    #    rewrite ^/en/(.*)$ /en/index.php?$query_string? last;
     #}
     #
     #location /en/ {


### PR DESCRIPTION
For the Forge example on a multi-site with subfolder setups, query strings aren't added to the URL rewrites.

To explain, we have a Craft install with two sites:
http://sitename.com/ - The UK site
http://sitename.com/australia-nz - The AU/NZ site

Let's say I visit http://sitename.com/australia-nz/query-test?test=something. I get the following dumping the request:

![Screen Shot on 2020-10-21 at 13:47:39](https://user-images.githubusercontent.com/1221575/96667046-0555b780-13a4-11eb-8dff-d93e04303825.png)

The query params are nowhere to be seen! After adding this change, the query params are present.

![Screen Shot on 2020-10-21 at 13:49:01](https://user-images.githubusercontent.com/1221575/96667137-31713880-13a4-11eb-9ee0-eaec27d18ebe.png)

Also gives the added bonus of not relying on `?p=` rewrites, and using `$query_string` is consistent with your other directives.