### PR TITLE
Fix repetition of `server_tokens`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Nginx-Craft Changelog
 
+## 1.0.32 - 2020.12.11
+### Changed
+* Removed repeated `server_tokens` within Primary block
+
 ## 1.0.31 - 2020.11.19
 ### Changed
 * Changed `public` to `web` for the server `root` example

--- a/sites-available/somedomain.com.conf
+++ b/sites-available/somedomain.com.conf
@@ -41,7 +41,6 @@ server {
 
     # General virtual host settings
     server_name SOMEDOMAIN.com;
-    server_tokens off;
     root "/var/www/SOMEDOMAIN/web";
     index index.html index.htm index.php;
     charset utf-8;


### PR DESCRIPTION
### Description
Removed repeated `server_tokens` within Primary block which was causing errors when running `nginx reload`.

### Related issues

n/a